### PR TITLE
remove deprecated strops.h

### DIFF
--- a/serial-grovel.lisp
+++ b/serial-grovel.lisp
@@ -5,7 +5,6 @@
 (include "fcntl.h")
 (include "stdio.h")
 (include "errno.h")
-(include "stropts.h")
 (include "fcntl.h")
 (include "stdlib.h")
 (include "unistd.h")


### PR DESCRIPTION
It was remove from glibc 2.30.
> The obsolete and never-implemented XSI STREAMS header files <stropts.h> and <sys/stropts.h> have been removed.
See https://sourceware.org/legacy-ml/libc-alpha/2019-08/msg00029.html